### PR TITLE
GRS-0028 Add genre filter to header bar

### DIFF
--- a/app/routes/main.py
+++ b/app/routes/main.py
@@ -6,6 +6,7 @@ This module handles all the web routes and API endpoints.
 from flask import Blueprint, render_template, request, jsonify, session, redirect, url_for
 from app.services.recommender import get_recommendations
 from app.services.platform_service import create_platform_service
+from app.services.genre_header_service import create_genre_service
 import pandas as pd
 import pickle
 import numpy as np
@@ -56,15 +57,24 @@ def select_favorites():
     offset = int(request.args.get('offset', 0))
     page_size = 20
     platform = request.args.get('platform', 'all')
+    genre = request.args.get('genre', 'all')
 
-    # Create platform service for filtering
+    # Create services for filtering
     platform_service = create_platform_service(games)
+    genre_service = create_genre_service(games)
 
-    # Filter games by platform first
+    # Start with all games
+    filtered_games = games
+
+    # Filter by platform first
     if platform != 'all':
         filtered_games = platform_service.filter_games_by_platform(platform)
-    else:
-        filtered_games = games
+
+    # Then filter by genre on the already filtered games
+    if genre != 'all':
+        # Create a new genre service with the already filtered games
+        genre_service_filtered = create_genre_service(filtered_games)
+        filtered_games = genre_service_filtered.filter_games_by_genre(genre)
 
     # Sort games by review count
     sorted_games = sorted(
@@ -137,7 +147,9 @@ def select_favorites():
         selected=selected_all,
         total_selected_count=total_selected_count,
         current_platform=platform,
-        selected_games_details=selected_games_details
+        current_genre=genre,
+        selected_games_details=selected_games_details,
+        show_genre_filter=True  # Show genre filter on favorites page
         )
 
 @bp.route('/update-game-selection', methods=['POST'])
@@ -174,12 +186,101 @@ def update_game_selection():
             'message': str(e)
         }), 400
 
+@bp.route('/api/genres')
+def get_genres():
+    """API endpoint to get all available genres from the dataset."""
+    try:
+        genre_service = create_genre_service(games)
+        # Get more genres to ensure we don't miss shooter subgenres
+        all_genres = genre_service.get_popular_genres(limit=100)  # Get top 100 genres
+
+        # Prioritize shooter-related genres and other important ones
+        shooter_keywords = ['shooter', 'fps', 'shoot', 'gun', 'combat', 'war']
+        important_genres = ['Action', 'Adventure', 'RPG', 'Strategy', 'Simulation', 'Sports', 'Racing', 'Puzzle', 'Platformer', 'Fighting', 'Horror', 'Survival', 'Sandbox', 'MMORPG', 'Indie', 'Casual', 'Multiplayer']
+
+        # Separate genres into categories
+        shooter_genres = []
+        important_genre_list = []
+        other_genres = []
+
+        for genre in all_genres:
+            genre_name_lower = genre['name'].lower()
+            if any(keyword in genre_name_lower for keyword in shooter_keywords):
+                shooter_genres.append(genre)
+            elif genre['name'] in important_genres:
+                important_genre_list.append(genre)
+            else:
+                other_genres.append(genre)
+
+        # Debug: Log what shooter genres we found
+        print(f"DEBUG: Found {len(shooter_genres)} shooter genres:")
+        for sg in shooter_genres:
+            print(f"  - {sg['name']}: {sg['count']} games")
+
+        # Combine: important genres first, then shooter genres, then others (limit to ~50 total)
+        final_genres = important_genre_list[:20] + shooter_genres + other_genres[:20]
+
+        # Format for frontend consumption
+        genres_data = [
+            {
+                'name': genre['name'],
+                'display': genre['name'],
+                'count': genre['count']
+            }
+            for genre in final_genres
+        ]
+
+        return jsonify({
+            'success': True,
+            'genres': genres_data,
+            'debug': {
+                'total_genres_found': len(all_genres),
+                'shooter_genres_count': len(shooter_genres),
+                'important_genres_count': len(important_genre_list),
+                'other_genres_count': len(other_genres),
+                'final_count': len(final_genres)
+            }
+        })
+    except Exception as e:
+        return jsonify({
+            'success': False,
+            'error': str(e)
+        }), 500
+
+@bp.route('/api/debug/all-genres')
+def debug_all_genres():
+    """Debug endpoint to see all genres in the dataset."""
+    try:
+        genre_service = create_genre_service(games)
+        all_genres = genre_service.get_popular_genres(limit=200)  # Get many genres
+
+        # Find shooter genres specifically
+        shooter_keywords = ['shooter', 'fps', 'shoot', 'gun', 'combat', 'war']
+        shooter_genres = []
+        for genre in all_genres:
+            if any(keyword in genre['name'].lower() for keyword in shooter_keywords):
+                shooter_genres.append(genre)
+
+        return jsonify({
+            'success': True,
+            'total_count': len(all_genres),
+            'shooter_count': len(shooter_genres),
+            'shooter_genres': [{'name': g['name'], 'count': g['count']} for g in shooter_genres],
+            'all_genres': [{'name': g['name'], 'count': g['count']} for g in all_genres[:50]]  # First 50 for brevity
+        })
+    except Exception as e:
+        return jsonify({
+            'success': False,
+            'error': str(e)
+        }), 500
+
 @bp.route('/recommendations', methods=['GET', 'POST'])
 def recommendations():
     # Get offset from query parameter (default to 0)
     offset = int(request.args.get('offset', 0))
     page_size = 20
     platform = request.args.get('platform', 'all')
+    genre = request.args.get('genre', 'all')
 
     game_ids = list(embeddings_dict.keys())
 
@@ -222,6 +323,11 @@ def recommendations():
             game_copy['similarity'] = similarity
             selected_games.append(game_copy)
 
+    # Apply genre filtering to recommendations if specified
+    if genre != 'all':
+        genre_service = create_genre_service(selected_games)
+        selected_games = genre_service.filter_games_by_genre(genre)
+
     next_offset = offset + page_size if offset + page_size < len(selected_games) else None
     previous_offset = max(offset - page_size, 0) if offset > 0 else None
 
@@ -234,5 +340,7 @@ def recommendations():
         games=paginated_games,
         next_offset=next_offset,
         previous_offset=previous_offset,
-        current_platform=platform
+        current_platform=platform,
+        current_genre=genre,
+        show_genre_filter=True  # Show genre filter on recommendations page
         )

--- a/app/services/genre_header_service.py
+++ b/app/services/genre_header_service.py
@@ -1,0 +1,115 @@
+from typing import List, Dict, Set, Optional
+from collections import Counter
+
+
+class GenreHeaderService:
+    def __init__(self, games_data: List[Dict]):
+        self.games_data = games_data
+        self._all_genres = None
+        self._genre_counts = None
+    
+    def get_all_genres(self) -> List[str]:
+        if self._all_genres is None:
+            genres_set = set()
+            for game in self.games_data:
+                genres_str = game.get('genres', '')
+                if genres_str:
+                    # Split by semicolon and clean up whitespace
+                    game_genres = [genre.strip() for genre in genres_str.split(';') if genre.strip()]
+                    genres_set.update(game_genres)
+            
+            self._all_genres = sorted(list(genres_set))
+        
+        return self._all_genres
+    
+    def get_genre_counts(self) -> Dict[str, int]:
+        if self._genre_counts is None:
+            genre_counter = Counter()
+            for game in self.games_data:
+                genres_str = game.get('genres', '')
+                if genres_str:
+                    game_genres = [genre.strip() for genre in genres_str.split(';') if genre.strip()]
+                    genre_counter.update(game_genres)
+            
+            self._genre_counts = dict(genre_counter)
+        
+        return self._genre_counts
+    
+    def get_popular_genres(self, limit: int = 20) -> List[Dict[str, any]]:
+        genre_counts = self.get_genre_counts()
+        sorted_genres = sorted(genre_counts.items(), key=lambda x: x[1], reverse=True)
+        
+        return [
+            {'name': genre, 'count': count}
+            for genre, count in sorted_genres[:limit]
+        ]
+    
+    def filter_games_by_genre(self, genre: str) -> List[Dict]:
+        if not genre or genre.lower() == 'all':
+            return self.games_data.copy()
+        
+        filtered_games = []
+        for game in self.games_data:
+            genres_str = game.get('genres', '')
+            if genres_str:
+                game_genres = [g.strip().lower() for g in genres_str.split(';') if g.strip()]
+                if genre.lower() in game_genres:
+                    filtered_games.append(game)
+        
+        return filtered_games
+    
+    def filter_games_by_multiple_genres(self, genres: List[str], match_all: bool = False) -> List[Dict]:
+        if not genres:
+            return self.games_data.copy()
+        
+        # Remove 'all' from genres list and normalize to lowercase
+        filter_genres = [g.lower() for g in genres if g.lower() != 'all']
+        
+        if not filter_genres:
+            return self.games_data.copy()
+        
+        filtered_games = []
+        for game in self.games_data:
+            genres_str = game.get('genres', '')
+            if genres_str:
+                game_genres = [g.strip().lower() for g in genres_str.split(';') if g.strip()]
+                
+                if match_all:
+                    # Game must have ALL specified genres
+                    if all(genre in game_genres for genre in filter_genres):
+                        filtered_games.append(game)
+                else:
+                    # Game must have ANY of the specified genres
+                    if any(genre in game_genres for genre in filter_genres):
+                        filtered_games.append(game)
+        
+        return filtered_games
+    
+    def get_genres_for_game(self, game: Dict) -> List[str]:
+        genres_str = game.get('genres', '')
+        if not genres_str:
+            return []
+        
+        return [genre.strip() for genre in genres_str.split(';') if genre.strip()]
+    
+    def get_genre_statistics(self) -> Dict[str, any]:
+        genre_counts = self.get_genre_counts()
+        all_genres = self.get_all_genres()
+        
+        total_games = len(self.games_data)
+        games_with_genres = sum(1 for game in self.games_data if game.get('genres', '').strip())
+        
+        return {
+            'total_genres': len(all_genres),
+            'total_games': total_games,
+            'games_with_genres': games_with_genres,
+            'games_without_genres': total_games - games_with_genres,
+            'most_popular_genre': max(genre_counts.items(), key=lambda x: x[1]) if genre_counts else None,
+            'least_popular_genre': min(genre_counts.items(), key=lambda x: x[1]) if genre_counts else None,
+            'average_games_per_genre': sum(genre_counts.values()) / len(genre_counts) if genre_counts else 0
+        }
+
+
+# Factory function to create genre service instance
+def create_genre_service(games_data: List[Dict]) -> GenreHeaderService:
+    return GenreHeaderService(games_data)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -51,18 +51,26 @@
                 <!--Don't forget to add color for light mode! -->
                 <span class="self-center text-2xl font-semibold whitespace-nowrap dark:text-white text-black transition-colors duration-500 delay-200">Game Recommender</span>
             </a>
-            
-            <!-- Theme toggle button -->
-            <button id="theme-toggle" type="button" class="text-gray-500 dark:text-gray-400 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5 border border-gray-300 dark:border-gray-600 cursor-pointer">
-                <!-- Moon icon for light mode (default visible) -->
-                <svg id="theme-toggle-dark-icon" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path>
-                </svg>
-                <!-- Sun icon for dark mode (default hidden) -->
-                <svg id="theme-toggle-light-icon" class="hidden w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" fill-rule="evenodd" clip-rule="evenodd"></path>
-                </svg>
-            </button>
+
+            <!-- Center section with Genre Filter -->
+            <div class="flex items-center space-x-4">
+                <!-- Genre Filter - Only show on pages with games -->
+                {% if show_genre_filter %}
+                    {% include "genre_filter.html" %}
+                {% endif %}
+
+                <!-- Theme toggle button -->
+                <button id="theme-toggle" type="button" class="text-gray-500 dark:text-gray-400 bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 focus:outline-none focus:ring-4 focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-2.5 border border-gray-300 dark:border-gray-600 cursor-pointer">
+                    <!-- Moon icon for light mode (default visible) -->
+                    <svg id="theme-toggle-dark-icon" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path>
+                    </svg>
+                    <!-- Sun icon for dark mode (default hidden) -->
+                    <svg id="theme-toggle-light-icon" class="hidden w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" fill-rule="evenodd" clip-rule="evenodd"></path>
+                    </svg>
+                </button>
+            </div>
 
         </div>
     </nav>
@@ -84,12 +92,15 @@
 
     <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/flowbite@3.1.2/dist/flowbite.min.js"></script>
+
     <!-- Load utility modules first -->
     <script src="{{ url_for('static', filename='js/utils.js') }}"></script>
     <script src="{{ url_for('static', filename='js/theme.js') }}"></script>
     <!-- Load main application script last -->
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
+    <!-- Include shared spinner -->
+    {% include "spinner.html" %}
 
     {% block scripts %}{% endblock %}
 </body>
-</html> 
+</html>

--- a/app/templates/genre_filter.html
+++ b/app/templates/genre_filter.html
@@ -1,0 +1,341 @@
+<!-- Genre Filter Component -->
+<div class="relative" id="header-genre-filter">
+    <button
+        id="header-genre-btn"
+        class="flex items-center space-x-2 px-4 py-2 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white rounded-lg transition-all duration-200 text-sm font-medium"
+        onclick="toggleHeaderGenreFilter()"
+    >
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"></path>
+        </svg>
+        <span id="header-genre-text">Genre Filter</span>
+        <svg id="header-genre-icon" class="w-4 h-4 transform transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+        </svg>
+    </button>
+
+    <!-- Full-Width Dropdown Menu -->
+    <div id="header-genre-dropdown" class="hidden fixed top-16 left-0 right-0 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 shadow-lg z-40">
+        <div class="relative px-6 py-4">
+            <!-- Left Scroll Arrow -->
+            <div id="scroll-left-arrow" class="absolute left-2 top-1/2 transform -translate-y-1/2 z-10 opacity-0 transition-opacity duration-300 pointer-events-none">
+                <button class="w-8 h-8 bg-gray-800 dark:bg-gray-600 text-white rounded-full flex items-center justify-center shadow-lg hover:bg-gray-700 dark:hover:bg-gray-500 transition-colors">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
+                    </svg>
+                </button>
+            </div>
+
+            <!-- Right Scroll Arrow -->
+            <div id="scroll-right-arrow" class="absolute right-2 top-1/2 transform -translate-y-1/2 z-10 opacity-0 transition-opacity duration-300 pointer-events-none">
+                <button class="w-8 h-8 bg-gray-800 dark:bg-gray-600 text-white rounded-full flex items-center justify-center shadow-lg hover:bg-gray-700 dark:hover:bg-gray-500 transition-colors">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                    </svg>
+                </button>
+            </div>
+
+            <!-- Scrollable Horizontal Genre Bar -->
+            <div id="genre-scroll-container" class="overflow-x-auto scrollbar-hide mx-8" style="scroll-behavior: smooth;">
+                <div id="genre-buttons-container" class="flex gap-2 min-w-max">
+                    <!-- All Genres -->
+                    <button
+                        class="header-genre-option px-3 py-1.5 text-sm rounded-full transition-all duration-200 font-medium whitespace-nowrap bg-blue-600 text-white flex-shrink-0"
+                        data-genre="all"
+                        onclick="selectHeaderGenre('all')"
+                    >
+                        All Genres
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    // Genre Filter
+    let headerGenreData = [];
+    let isHeaderGenreDropdownOpen = false;
+
+    function toggleHeaderGenreFilter() {
+        const dropdown = document.getElementById('header-genre-dropdown');
+        const icon = document.getElementById('header-genre-icon');
+        
+        isHeaderGenreDropdownOpen = !isHeaderGenreDropdownOpen;
+        
+        if (isHeaderGenreDropdownOpen) {
+            dropdown.classList.remove('hidden');
+            icon.classList.add('rotate-180');
+
+            // Load genre data if not already loaded
+            if (headerGenreData.length === 0) {
+                loadHeaderGenreData();
+            }
+        } else {
+            dropdown.classList.add('hidden');
+            icon.classList.remove('rotate-180');
+        }
+    }
+
+    function loadHeaderGenreData() {
+        // Fetch genres dynamically from the API
+        fetch('/api/genres')
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    headerGenreData = data.genres;
+                    populateHeaderGenreDropdown();
+                } else {
+                    console.error('Failed to load genres:', data.error);
+                    // Fallback to basic genres if API fails
+                    headerGenreData = [
+                        { name: 'Action', display: 'Action' },
+                        { name: 'Adventure', display: 'Adventure' },
+                        { name: 'RPG', display: 'RPG' },
+                        { name: 'Strategy', display: 'Strategy' },
+                        { name: 'Simulation', display: 'Simulation' },
+                        { name: 'Sports', display: 'Sports' },
+                        { name: 'Racing', display: 'Racing' },
+                        { name: 'Indie', display: 'Indie' },
+                        { name: 'Casual', display: 'Casual' }
+                    ];
+                    populateHeaderGenreDropdown();
+                }
+            })
+            .catch(error => {
+                console.error('Error fetching genres:', error);
+                // Fallback to basic genres if fetch fails
+                headerGenreData = [
+                    { name: 'Action', display: 'Action' },
+                    { name: 'Adventure', display: 'Adventure' },
+                    { name: 'RPG', display: 'RPG' },
+                    { name: 'Strategy', display: 'Strategy' },
+                    { name: 'Simulation', display: 'Simulation' },
+                    { name: 'Sports', display: 'Sports' },
+                    { name: 'Racing', display: 'Racing' },
+                    { name: 'Indie', display: 'Indie' },
+                    { name: 'Casual', display: 'Casual' }
+                ];
+                populateHeaderGenreDropdown();
+            });
+    }
+
+    function populateHeaderGenreDropdown() {
+        const container = document.getElementById('genre-buttons-container');
+        if (!container) return;
+
+        // Clear existing buttons except "All Genres"
+        const allGenresBtn = container.querySelector('[data-genre="all"]');
+        container.innerHTML = '';
+        if (allGenresBtn) {
+            container.appendChild(allGenresBtn);
+        }
+
+        // Add all available genres from the API
+        headerGenreData.forEach(genre => {
+            const button = document.createElement('button');
+            button.className = 'header-genre-option px-3 py-1.5 text-sm rounded-full transition-all duration-200 font-medium whitespace-nowrap bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-500 flex-shrink-0';
+            button.setAttribute('data-genre', genre.name);
+            button.onclick = () => selectHeaderGenre(genre.name);
+            button.textContent = genre.display;
+            container.appendChild(button);
+        });
+
+        // Setup scroll arrows after a brief delay to ensure DOM is ready
+        setTimeout(() => {
+            setupScrollArrows();
+        }, 50);
+        updateHeaderGenreText(getCurrentGenre());
+    }
+
+    function setupScrollArrows() {
+        const container = document.getElementById('genre-scroll-container');
+        const leftArrow = document.getElementById('scroll-left-arrow');
+        const rightArrow = document.getElementById('scroll-right-arrow');
+
+        if (!container || !leftArrow || !rightArrow) return;
+
+        function updateArrowVisibility() {
+            const { scrollLeft, scrollWidth, clientWidth } = container;
+            const buttonsContainer = document.getElementById('genre-buttons-container');
+            const buttonCount = buttonsContainer ? buttonsContainer.children.length : 0;
+
+            // Show arrows if we have many genres (more than 10) or if content actually overflows
+            const hasOverflow = scrollWidth > clientWidth + 5;
+            const hasManyGenres = buttonCount > 10;
+            const shouldShowArrows = hasOverflow || hasManyGenres;
+
+            console.log('Arrow visibility:', {
+                scrollLeft, scrollWidth, clientWidth, buttonCount,
+                hasOverflow, hasManyGenres, shouldShowArrows
+            });
+
+            if (!shouldShowArrows) {
+                // Hide both arrows
+                leftArrow.classList.add('opacity-0', 'pointer-events-none');
+                leftArrow.classList.remove('opacity-100', 'pointer-events-auto');
+                rightArrow.classList.add('opacity-0', 'pointer-events-none');
+                rightArrow.classList.remove('opacity-100', 'pointer-events-auto');
+                return;
+            }
+
+            // Show left arrow if we can scroll left
+            if (scrollLeft > 0) {
+                leftArrow.classList.remove('opacity-0', 'pointer-events-none');
+                leftArrow.classList.add('opacity-100', 'pointer-events-auto');
+            } else {
+                leftArrow.classList.add('opacity-0', 'pointer-events-none');
+                leftArrow.classList.remove('opacity-100', 'pointer-events-auto');
+            }
+
+            // Show right arrow if we can scroll right OR if we have many genres and haven't scrolled yet
+            const canScrollRight = scrollLeft < scrollWidth - clientWidth - 1;
+            const showRightArrow = canScrollRight || (hasManyGenres && scrollLeft === 0);
+
+            if (showRightArrow) {
+                rightArrow.classList.remove('opacity-0', 'pointer-events-none');
+                rightArrow.classList.add('opacity-100', 'pointer-events-auto');
+            } else {
+                rightArrow.classList.add('opacity-0', 'pointer-events-none');
+                rightArrow.classList.remove('opacity-100', 'pointer-events-auto');
+            }
+        }
+
+        // Initial check with delay to ensure DOM is rendered
+        setTimeout(() => {
+            updateArrowVisibility();
+        }, 100);
+
+        // Update on scroll
+        container.addEventListener('scroll', updateArrowVisibility);
+
+        // Also update on window resize
+        window.addEventListener('resize', updateArrowVisibility);
+
+        // Arrow click handlers
+        leftArrow.querySelector('button').onclick = () => {
+            container.scrollBy({ left: -200, behavior: 'smooth' });
+        };
+
+        rightArrow.querySelector('button').onclick = () => {
+            container.scrollBy({ left: 200, behavior: 'smooth' });
+        };
+    }
+
+    function getCurrentGenre() {
+        const urlParams = new URLSearchParams(window.location.search);
+        return urlParams.get('genre') || 'all';
+    }
+
+    function updateHeaderGenreText(selectedGenre) {
+        const genreText = document.getElementById('header-genre-text');
+        if (!genreText) return;
+
+        if (selectedGenre === 'all') {
+            genreText.textContent = 'Genre Filter';
+        } else {
+            // Find the display name for the genre
+            const genreData = headerGenreData.find(g => g.name === selectedGenre);
+            const displayName = genreData ? genreData.display : selectedGenre;
+            genreText.textContent = displayName;
+        }
+
+        // Update button states
+        const buttons = document.querySelectorAll('.header-genre-option');
+        buttons.forEach(button => {
+            const buttonGenre = button.getAttribute('data-genre');
+            if (buttonGenre === selectedGenre) {
+                button.className = 'header-genre-option px-3 py-1.5 text-sm rounded-full transition-all duration-200 font-medium whitespace-nowrap bg-blue-600 text-white flex-shrink-0';
+            } else {
+                button.className = 'header-genre-option px-3 py-1.5 text-sm rounded-full transition-all duration-200 font-medium whitespace-nowrap bg-gray-200 dark:bg-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-500 flex-shrink-0';
+            }
+        });
+    }
+
+    function selectHeaderGenre(genre) {
+        // Show the same spinner used for platform selection
+        const spinnerOverlay = document.getElementById('spinnerOverlay');
+        if (spinnerOverlay) {
+            spinnerOverlay.style.display = 'flex';
+        }
+
+        // Get current URL parameters
+        const urlParams = new URLSearchParams(window.location.search);
+
+        // Update or remove genre parameter
+        if (genre === 'all') {
+            urlParams.delete('genre');
+        } else {
+            urlParams.set('genre', genre);
+        }
+
+        // Reset offset when changing genre
+        urlParams.delete('offset');
+
+        // Build new URL
+        const newUrl = window.location.pathname + (urlParams.toString() ? '?' + urlParams.toString() : '');
+
+        // Add a small delay to show the spinner before navigation (same as platform selection)
+        setTimeout(() => {
+            window.location.href = newUrl;
+        }, 400);
+    }
+
+    // Close dropdown when clicking outside
+    document.addEventListener('click', function(event) {
+        const genreFilter = document.getElementById('header-genre-filter');
+        const dropdown = document.getElementById('header-genre-dropdown');
+        
+        if (genreFilter && dropdown && !genreFilter.contains(event.target)) {
+            if (isHeaderGenreDropdownOpen) {
+                toggleHeaderGenreFilter();
+            }
+        }
+    });
+
+    // Initialize genre filter when DOM is loaded
+    document.addEventListener('DOMContentLoaded', function() {
+        const genreFilter = document.getElementById('header-genre-filter');
+        if (genreFilter) {
+            updateHeaderGenreText(getCurrentGenre());
+            loadHeaderGenreData();
+        }
+    });
+</script>
+
+<style>
+    /* Hide scrollbar for genre container */
+    .scrollbar-hide {
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+    }
+    .scrollbar-hide::-webkit-scrollbar {
+        display: none;
+    }
+
+    /* Smooth scrolling for genre container */
+    #genre-scroll-container {
+        scroll-behavior: smooth;
+    }
+
+    /* Genre button hover effects */
+    .header-genre-option {
+        transform-origin: center;
+    }
+
+    .header-genre-option:hover {
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    }
+
+    /* Responsive adjustments for horizontal bar */
+    @media (max-width: 768px) {
+        #header-genre-dropdown .flex {
+            gap: 0.375rem;
+        }
+
+        .header-genre-option {
+            font-size: 0.7rem;
+            padding: 0.25rem 0.5rem;
+        }
+    }
+</style>

--- a/app/templates/recommendations.html
+++ b/app/templates/recommendations.html
@@ -16,7 +16,7 @@
 <!-- Controls if the buttons for loading more games appears or not -->
 <div class="flex justify-between mt-4">
   {% if previous_offset is not none %}
-    <a href="?offset={{ previous_offset }}" class="px-4 py-2 bg-gray-300 hover:bg-gray-400 rounded text-black">
+    <a href="?offset={{ previous_offset }}{% if current_platform %}&platform={{ current_platform }}{% endif %}{% if current_genre and current_genre != 'all' %}&genre={{ current_genre }}{% endif %}" class="px-4 py-2 bg-gray-300 hover:bg-gray-400 rounded text-black">
       ← Previous
     </a>
   {% else %}
@@ -24,7 +24,7 @@
   {% endif %}
   
   {% if next_offset is not none %}
-    <a href="?offset={{ next_offset }}" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded text-white">
+    <a href="?offset={{ next_offset }}{% if current_platform %}&platform={{ current_platform }}{% endif %}{% if current_genre and current_genre != 'all' %}&genre={{ current_genre }}{% endif %}" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded text-white">
       Next →
     </a>
   {% endif %}

--- a/app/templates/select_favorites.html
+++ b/app/templates/select_favorites.html
@@ -20,7 +20,7 @@
 
 <div class="flex justify-between mt-4">
   {% if previous_offset is not none %}
-    <a href="?offset={{ previous_offset }}{% if current_platform %}&platform={{ current_platform }}{% endif %}" class="px-4 py-2 bg-gray-300 hover:bg-gray-400 rounded text-black">
+    <a href="?offset={{ previous_offset }}{% if current_platform %}&platform={{ current_platform }}{% endif %}{% if current_genre and current_genre != 'all' %}&genre={{ current_genre }}{% endif %}" class="px-4 py-2 bg-gray-300 hover:bg-gray-400 rounded text-black">
       ← Previous Page
     </a>
   {% else %}
@@ -28,7 +28,7 @@
   {% endif %}
   
   {% if next_offset is not none %}
-    <a href="?offset={{ next_offset }}{% if current_platform %}&platform={{ current_platform }}{% endif %}" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded text-white">
+    <a href="?offset={{ next_offset }}{% if current_platform %}&platform={{ current_platform }}{% endif %}{% if current_genre and current_genre != 'all' %}&genre={{ current_genre }}{% endif %}" class="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded text-white">
       Next Page →
     </a>
   {% endif %}

--- a/app/tests/test_genre_header_service.py
+++ b/app/tests/test_genre_header_service.py
@@ -1,0 +1,155 @@
+"""
+Tests for the Genre Header Service.
+"""
+
+import pytest
+from app.services.genre_header_service import GenreHeaderService, create_genre_service
+
+
+class TestGenreHeaderService:
+    
+    @pytest.fixture
+    def sample_games_data(self):
+        return [
+            {
+                'appid': 1,
+                'name': 'Action Game',
+                'genres': 'Action;FPS;Multiplayer'
+            },
+            {
+                'appid': 2,
+                'name': 'Strategy Game',
+                'genres': 'Strategy;RTS;War'
+            },
+            {
+                'appid': 3,
+                'name': 'Indie Puzzle',
+                'genres': 'Indie;Puzzle;Casual'
+            },
+            {
+                'appid': 4,
+                'name': 'Action RPG',
+                'genres': 'Action;RPG;Adventure'
+            },
+            {
+                'appid': 5,
+                'name': 'No Genre Game',
+                'genres': ''
+            },
+            {
+                'appid': 6,
+                'name': 'Racing Game',
+                'genres': 'Racing;Sports;Simulation'
+            }
+        ]
+    
+    @pytest.fixture
+    def genre_service(self, sample_games_data):
+        """Create a GenreHeaderService instance for testing."""
+        return GenreHeaderService(sample_games_data)
+    
+    def test_get_all_genres(self, genre_service):
+        """Test getting all unique genres."""
+        genres = genre_service.get_all_genres()
+        
+        expected_genres = [
+            'Action', 'Adventure', 'Casual', 'FPS', 'Indie', 
+            'Multiplayer', 'Puzzle', 'RPG', 'RTS', 'Racing', 
+            'Simulation', 'Sports', 'Strategy', 'War'
+        ]
+        
+        assert sorted(genres) == sorted(expected_genres)
+        assert len(genres) == 14
+    
+    def test_get_genre_counts(self, genre_service):
+        """Test getting genre counts."""
+        counts = genre_service.get_genre_counts()
+        
+        assert counts['Action'] == 2  
+        assert counts['Strategy'] == 1  
+        assert counts['Indie'] == 1 
+        assert counts['Racing'] == 1 
+    
+    def test_get_popular_genres(self, genre_service):
+        """Test getting popular genres."""
+        popular = genre_service.get_popular_genres(limit=5)
+        
+        assert popular[0]['name'] == 'Action'
+        assert popular[0]['count'] == 2
+        
+        # All others should have count of 1
+        for genre_info in popular[1:]:
+            assert genre_info['count'] == 1
+    
+    def test_filter_games_by_genre(self, genre_service):
+        """Test filtering games by a single genre."""
+        action_games = genre_service.filter_games_by_genre('Action')
+        assert len(action_games) == 2
+        assert action_games[0]['appid'] == 1
+        assert action_games[1]['appid'] == 4
+        
+        strategy_games = genre_service.filter_games_by_genre('Strategy')
+        assert len(strategy_games) == 1
+        assert strategy_games[0]['appid'] == 2
+        
+        # Test case insensitive
+        action_games_lower = genre_service.filter_games_by_genre('action')
+        assert len(action_games_lower) == 2
+    
+    def test_filter_games_by_genre_all(self, genre_service):
+        """Test filtering with 'all' returns all games."""
+        all_games = genre_service.filter_games_by_genre('all')
+        assert len(all_games) == 6
+        
+        all_games_empty = genre_service.filter_games_by_genre('')
+        assert len(all_games_empty) == 6
+    
+    def test_filter_games_by_multiple_genres_any(self, genre_service):
+        """Test filtering by multiple genres (ANY match)."""
+        # Games with Action OR Strategy
+        games = genre_service.filter_games_by_multiple_genres(['Action', 'Strategy'], match_all=False)
+        assert len(games) == 3  # Games 1, 2, and 4
+        
+        game_ids = [game['appid'] for game in games]
+        assert 1 in game_ids  # Action game
+        assert 2 in game_ids  # Strategy game
+        assert 4 in game_ids  # Action RPG
+    
+    def test_filter_games_by_multiple_genres_all(self, genre_service):
+        """Test filtering by multiple genres (ALL match)."""
+        # Games with both Action AND RPG
+        games = genre_service.filter_games_by_multiple_genres(['Action', 'RPG'], match_all=True)
+        assert len(games) == 1
+        assert games[0]['appid'] == 4  # Action RPG game
+        
+        # Games with Action AND Strategy (should be none)
+        games = genre_service.filter_games_by_multiple_genres(['Action', 'Strategy'], match_all=True)
+        assert len(games) == 0
+    
+    def test_get_genres_for_game(self, genre_service, sample_games_data):
+        """Test getting genres for a specific game."""
+        action_game = sample_games_data[0]  # Action;FPS;Multiplayer
+        genres = genre_service.get_genres_for_game(action_game)
+        
+        assert genres == ['Action', 'FPS', 'Multiplayer']
+        
+        no_genre_game = sample_games_data[4]  # Empty genres
+        genres = genre_service.get_genres_for_game(no_genre_game)
+        assert genres == []
+    
+    def test_get_genre_statistics(self, genre_service):
+        """Test getting genre statistics."""
+        stats = genre_service.get_genre_statistics()
+        
+        assert stats['total_genres'] == 14
+        assert stats['total_games'] == 6
+        assert stats['games_with_genres'] == 5  # 5 games have genres
+        assert stats['games_without_genres'] == 1  # 1 game has no genres
+        assert stats['most_popular_genre'] == ('Action', 2)
+        assert stats['average_games_per_genre'] > 0
+    
+    def test_create_genre_service_factory(self, sample_games_data):
+        """Test the factory function."""
+        service = create_genre_service(sample_games_data)
+        assert isinstance(service, GenreHeaderService)
+        assert len(service.get_all_genres()) == 14


### PR DESCRIPTION
## Changes

- Add genre filter to the header bar
- Genre filter only appears on favorites page and game recommended page

## Test Instructions

1. Pull from the branch
2. Pass `Start` page and `Select_platform` page
3. Click `Genre Filter` from the header bar

Before

<img width="1875" height="370" alt="image" src="https://github.com/user-attachments/assets/53bea651-2bd5-45bb-bcb0-9928bed3e951" />

After

<img width="1900" height="219" alt="image" src="https://github.com/user-attachments/assets/694ffc25-0faa-4d3e-89aa-7c211d06b3c9" />

